### PR TITLE
Uat into Master

### DIFF
--- a/ckanext/clone_dataset/blueprint.py
+++ b/ckanext/clone_dataset/blueprint.py
@@ -82,7 +82,14 @@ def clone(id):
         return h.redirect_to('/dataset')
     except Exception as e:
         log.error(str(e))
-        h.flash_error('Error cloning dataset.')
+        msg="""
+        <p>The cloned dataset contains invalid entries:</p>
+        <ul>"""
+        for key,error in e.error_summary.items():
+            msg += "<li>" + key + ": " + error + "</li>"
+         
+        msg+= """</ul>"""
+        h.flash_error(msg, allow_html=True)
         return h.redirect_to('/dataset')
 
 

--- a/ckanext/clone_dataset/blueprint.py
+++ b/ckanext/clone_dataset/blueprint.py
@@ -1,33 +1,30 @@
-import ckan.logic as logic
+import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import logging
 import datetime
 
-from pprint import pformat
 from flask import Blueprint
-from ckan.plugins.toolkit import get_action
 from ckanext.clone_dataset.helpers import get_incremental_package_name
+from ckanext.clone_dataset.interfaces import IClone
 
-clean_dict = logic.clean_dict
-h = toolkit.h
 log = logging.getLogger(__name__)
-parse_params = logic.parse_params
+h = toolkit.h
 request = toolkit.request
-tuplize_dict = logic.tuplize_dict
 NotAuthorized = toolkit.NotAuthorized
+get_action = toolkit.get_action
+check_access = toolkit.check_access
 
-clone_dataset = Blueprint('clone_dataset', __name__, url_prefix=u'/ckan-admin')
+clone_dataset = Blueprint('clone_dataset', __name__)
 
 
 def clone(id):
     # Get current dataset.
     try:
         # Need to set the user info in the context for check_access
-        context = {'user': toolkit.g.user, 'userobj': toolkit.g.userobj}
+        context = {'user': toolkit.g.user, 'auth_user_obj': toolkit.g.userobj}
+        dataset_dict = get_action('package_show')(context.copy(), {'id': id})
         # Check the user has permission to clone the dataset
-        toolkit.check_access('package_update', context, {'id': id})
-
-        dataset_dict = get_action('package_show')({}, {'id': id})
+        check_access('package_create', context.copy(), dataset_dict)
     except NotAuthorized as e:
         log.error(str(e))
         h.flash_error(str(e))
@@ -49,17 +46,11 @@ def clone(id):
 
     dataset_dict.pop('id')
 
-    if 'identifiers' in dataset_dict:
-        dataset_dict['identifiers'] = None
-
     if 'revision_id' in dataset_dict:
         dataset_dict.pop('revision_id')
 
     if 'revision_timestamp' in dataset_dict:
         dataset_dict.pop('revision_timestamp')
-
-    if 'metadata_review_date' in dataset_dict:
-        dataset_dict.pop('metadata_review_date')
 
     # Drop resources.
     if 'resources' in dataset_dict:
@@ -70,14 +61,11 @@ def clone(id):
         dataset_dict.pop('relationships_as_object')
     if 'relationships_as_subject' in dataset_dict:
         dataset_dict.pop('relationships_as_subject')
-    # Also drop any specific fields that may contain references that trigger relationship creation
-    if 'series_or_collection' in dataset_dict:
-        dataset_dict.pop('series_or_collection')
-    if 'related_resources' in dataset_dict:
-        dataset_dict.pop('related_resources')
 
     try:
-        get_action('package_create')({}, dataset_dict)
+        for plugin in plugins.PluginImplementations(IClone):
+            plugin.clone_modify_dataset(context, dataset_dict)
+        get_action('package_create')(context, dataset_dict)
         h.flash_success('Dataset %s is created.' % dataset_dict['title'])
         return h.redirect_to('/dataset')
     except Exception as e:

--- a/ckanext/clone_dataset/interfaces.py
+++ b/ckanext/clone_dataset/interfaces.py
@@ -1,0 +1,19 @@
+
+from ckan.plugins.interfaces import Interface
+
+
+class IClone(Interface):
+    u'''
+    This interface allows plugins to hook into the Clone workflow
+    '''
+    def clone_modify_dataset(self, context, dataset_dict):
+        u'''
+        Allow extensions to modify the dataset dictionary before the new cloned dataset is created
+
+        :param context: The context object of the current request, this
+            includes for example access to the ``model`` and the ``user``.
+        :type context: dictionary
+        :param dataset_dict: Dataset dictionary from source dataset via package_show action that can be modified before it is created via the package_create action.
+        :type resource: dictionary
+        '''
+        pass

--- a/ckanext/clone_dataset/overrides.py
+++ b/ckanext/clone_dataset/overrides.py
@@ -44,7 +44,7 @@ def _check_group_auth(context, data_dict):
         groups = groups - set(pkg_groups)
 
     for group in groups:
-        # QDES Modification.
+        # Modification.
         # Only check user permission if group is not an organisation and is not coming from clone_dataset
         # When we a cloning a dataset we need to ignore group (categories)
         # Any user can add their organisation datasets to a category

--- a/ckanext/clone_dataset/templates/snippets/package_item.html
+++ b/ckanext/clone_dataset/templates/snippets/package_item.html
@@ -3,7 +3,7 @@
 {% block content %}
     {% asset 'clone_dataset/clone-dataset' %}
     {{ super() }}
-    {% if h.check_access('package_update', {'id':package.id }) %}
+    {% if h.check_access('package_create', {'id':package.id, 'type': package.type }) %}
     <div class="clone-dataset" style="display: none">
         <a href="{{ h.url_for('clone_dataset.clone', id=package.id) }}" data-module="confirm-action" data-module-content="Are you sure you want to clone this dataset?" class="btn btn-sm btn-primary">Clone</a>
     </div>


### PR DESCRIPTION
Added new interface so extensions can apply their own custom business logic to update dataset dict before created
Removed QDES custom business logic
Cleaned up code
Fixed clone check_access check by using package_create and passing in the whole data_dict from the dataset that will be cloned.
Only used a copy of the context because they will set the package which causes issues in package_create where it gets the package ID and updates the dataset instead of creating a new one.
Updated the package_item template to pass in package type so the access check works correctly on showing the link button